### PR TITLE
Final Post Endpoints (I Think)

### DIFF
--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -32,4 +32,65 @@ public class PostController : ControllerBase
             .OrderByDescending(p => p.PublishingDate)
             .ToList());
     }
+
+    //GET post by id
+    [HttpGet("{id}")]
+    //[Authorize]
+    public IActionResult GetById(int id)
+    {
+        Post post = _dbContext
+            .Posts
+            .Include(p => p.Category)
+            .Include(p => p.Author)
+                .ThenInclude(up => up.IdentityUser)
+            .Include(p => p.Reactions)
+            .SingleOrDefault(p => p.Id == id);
+
+        if (post == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(post);
+    }
+
+    //DELETE: api/Post/{id}
+    [HttpDelete("{id}")]
+    //[Authorize]
+    public IActionResult DeletePost(int id)
+    {
+        Post post = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+
+        if (post == null)
+        {
+            return NotFound();
+        }
+
+        _dbContext.Posts.Remove(post);
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
+
+    //Create Post
+    //Raw Body Test Data:
+    /*
+    {
+        "title": "Exploring Blazor for Web Development",
+        "subTitle": "Modern .NET-powered frontend",
+        "categoryId": 4,
+        "headerImageUrl": "https://example.com/images/blazor.jpg",
+        "body": "Blazor offers an exciting way to write web UIs using C# instead of JavaScript...",
+        "authorId": 2
+    }
+    */
+    [HttpPost]
+    //[Authorize]
+    public IActionResult CreateWorkOrder(Post post)
+    {
+        post.PublishingDate = DateTime.Now;
+        _dbContext.Posts.Add(post);
+        _dbContext.SaveChanges();
+        return Created($"/api/post/{post.Id}", post);
+    }
 }

--- a/Controllers/PostController.cs
+++ b/Controllers/PostController.cs
@@ -72,7 +72,7 @@ public class PostController : ControllerBase
         return NoContent();
     }
 
-    //Create Post
+    //POST Post (yeah yeah confusing but deal with it)
     //Raw Body Test Data:
     /*
     {
@@ -86,11 +86,83 @@ public class PostController : ControllerBase
     */
     [HttpPost]
     //[Authorize]
-    public IActionResult CreateWorkOrder(Post post)
+    public IActionResult CreatePost(Post post)
     {
         post.PublishingDate = DateTime.Now;
         _dbContext.Posts.Add(post);
         _dbContext.SaveChanges();
         return Created($"/api/post/{post.Id}", post);
     }
+
+    //GET all posts for a logged in user
+    [HttpGet("mine")]
+    //[Authorize]
+    public IActionResult GetMyPosts()
+    {
+        string currentUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        if (currentUserId == null)
+        {
+            return Unauthorized();
+        }
+
+        UserProfile userProfile = _dbContext
+            .UserProfiles
+            .FirstOrDefault(u => u.IdentityUserId == currentUserId);
+
+        if (userProfile == null)
+        {
+            return Unauthorized();
+        }
+
+        List<Post> userPosts = _dbContext
+            .Posts
+            .Where(p => p.AuthorId == userProfile.Id)
+            .OrderByDescending(p => p.PublishingDate)
+            .ToList();
+
+        return Ok(userPosts);
+    }
+
+    // PUT: api/Post/{id}
+    /*
+    {
+    "id": 2,
+    "title": "Updated Post Title",
+    "subTitle": "Updated subtitle",
+    "categoryId": 2,
+    "headerImageUrl": "https://example.com/images/updated-image.jpg",
+    "body": "This is the updated body content of the post. It has been revised for clarity and depth.",
+    "authorId": 2
+    }
+    */
+    [HttpPut("{id}")]
+    //[Authorize]
+    public IActionResult UpdatePost(Post post, int id)
+    {
+        Post postToUpdate = _dbContext.Posts.SingleOrDefault(p => p.Id == id);
+
+        if (postToUpdate == null)
+        {
+            return NotFound();
+        }
+        else if (id != post.Id)
+        {
+            return BadRequest();
+        }
+
+        // Only update editable fields
+        postToUpdate.Title = post.Title;
+        postToUpdate.SubTitle = post.SubTitle;
+        postToUpdate.CategoryId = post.CategoryId;
+        postToUpdate.HeaderImageUrl = post.HeaderImageUrl;
+        postToUpdate.Body = post.Body;
+        postToUpdate.AuthorId = post.AuthorId;
+
+        _dbContext.SaveChanges();
+
+        return NoContent();
+    }
+
+
 }

--- a/Models/Post.cs
+++ b/Models/Post.cs
@@ -35,4 +35,8 @@ public class Post
             return (int)Math.Ceiling(wordCount / 200.0);
         }
     }
+    public Category Category { get; set; }
+    public UserProfile Author { get; set; }
+    public List<Reaction> Reactions { get; set; }
+
 }


### PR DESCRIPTION
**Title:** ✨ Add CRUD Endpoints to `PostController`

---

### 📋 Summary

This PR adds five new endpoints to the `PostController` to enable full create, read, update, and delete (CRUD) functionality for `Post` resources. It also introduces a user-specific query for retrieving authored posts.

---

### ✅ What's Included

* [x] **GET** `/api/post/{id}` – Fetch a post by ID
* [x] **DELETE** `/api/post/{id}` – Delete a post by ID
* [x] **POST** `/api/post` – Create a new post
* [x] **PUT** `/api/post/{id}` – Update an existing post
* [x] **GET** `/api/post/mine` – Retrieve posts authored by the current user

---

### 🔐 Authorization Notes

> All endpoints have `[Authorize]` attributes prepared but currently commented out for testing purposes. These can be uncommented before deploying to production for secure access.

---

### 🧪 Testing Checklist

Use Postman, Swagger, or any HTTP client to validate the following scenarios:

* [x] Can retrieve a post by valid ID
* [x] Returns `404` on invalid post ID fetch or delete
* [x] Can create a post with valid data
* [x] Can update an existing post (only editable fields)
* [x] Returns `400` on ID mismatch during update
* [x] Can delete a post by ID
* [x] Authenticated users can fetch only their own posts via `/mine`
* [x] Returns `401` when unauthenticated user tries to access `/mine`

---

### 📌 Tags & References

* Closes #`<insert-issue-number-if-any>`
* Enhances backend CRUD capabilities
* Prepares the foundation for frontend integration of blog post features